### PR TITLE
Extremely small grammatical error I noticed

### DIFF
--- a/src/getting_started/onboarding/03_sv.md
+++ b/src/getting_started/onboarding/03_sv.md
@@ -49,7 +49,7 @@ statement.
 
 ## Exercise 2: Sequential Logic
 
-Implement a xor-based Fibonacci Linear Feedback Shift Register with taps at bits
+Implement an xor-based Fibonacci Linear Feedback Shift Register with taps at bits
 15, 13, 12, and 10. If the reset is low, the LFSR should be initialized with the
 value present on the init input bus.
 


### PR DESCRIPTION
Just trying to contribute while lab 2 is down for me, noticed a small grammatical error. Since XOR is an abbreviation and begins with a vowel sound, the article should be  `an`, not `a`.