### PR TITLE
Correct Homebrew shellenv command syntax

### DIFF
--- a/src/getting_started/development/01_homebrew.md
+++ b/src/getting_started/development/01_homebrew.md
@@ -121,7 +121,7 @@ you use to unlock your computer
   echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/test/.zprofile
   ```
   ```console
-  eval "$(/opt/homebrew/bin/brew/ shellenv)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
   ```
 
 - Run the following command to confirm your installation


### PR DESCRIPTION
Remove that extra '/' because 'brew/' is not a directory Running eval "$(/opt/homebrew/bin/brew/ shellenv)" gives the error:
zsh: not a directory: /opt/homebrew/bin/brew/